### PR TITLE
fix(deps): decrement tokio to 1.36

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ rust-version = "1.75.0"
 [dependencies]
 futures = { version = "0.3.30", optional = true }
 indexmap = "2.2.6"
-tokio = { version = "1.37.0", features = ["io-util", "macros", "process", "rt"], optional = true }
+tokio = { version = "1.36.0", features = ["io-util", "macros", "process", "rt"], optional = true }
 tracing = { version = "0.1.40", optional = true }
 
 [target.'cfg(unix)'.dependencies]


### PR DESCRIPTION
Temporary branch until tokio spec comes in line with pinned version found in denoland/deno. (1.36).